### PR TITLE
PreventDefault if element is not valid

### DIFF
--- a/htmx.ext.shoelace.js
+++ b/htmx.ext.shoelace.js
@@ -28,6 +28,10 @@ htmx.defineExtension('shoelace', {
 		if ((name === "htmx:configRequest") && (evt.detail.elt.tagName === 'FORM')) {
 			evt.detail.elt.querySelectorAll(slTypes).forEach((elt) => {
 				if (shouldInclude(elt)) {
+					if (!elt.checkValidity()) {
+                          			evt.preventDefault();
+                          			return;
+                      			}
 					if (elt.tagName === 'SL-CHECKBOX' || elt.tagName === 'SL-SWITCH') {
 						// Shoelace normally does this bit internally when the formdata event fires, but htmx doesn't fire the formdata event, so we do it here instead. See https://github.com/shoelace-style/shoelace/issues/1891
 						evt.detail.parameters[elt.name] = elt.value || 'on'


### PR DESCRIPTION
If the element is valid, prevent allowing htmx to continue on to send an ajax request on form submissions.

https://github.com/benopotamus/htmx-ext-shoelace/issues/10